### PR TITLE
DP for top-k segmentations

### DIFF
--- a/AutoCarver/combinations/binary/binary_combination_evaluators.py
+++ b/AutoCarver/combinations/binary/binary_combination_evaluators.py
@@ -1,5 +1,6 @@
 """Module for binary combination evaluators."""
 
+import math
 from abc import ABC
 from collections.abc import Iterable, Iterator
 
@@ -12,9 +13,11 @@ from AutoCarver.combinations.binary.binary_target_rates import BinaryTargetRate,
 from AutoCarver.combinations.utils.combination_evaluator import (
     AggregatedSample,
     CombinationEvaluator,
+    _nan_fanout_variants,
 )
 from AutoCarver.combinations.utils.combinations import combination_formatter
 from AutoCarver.combinations.utils.target_rate import TargetRate
+from AutoCarver.features import GroupedList
 
 
 class BinaryCombinationEvaluator(CombinationEvaluator[pd.DataFrame], ABC):
@@ -25,6 +28,9 @@ class BinaryCombinationEvaluator(CombinationEvaluator[pd.DataFrame], ABC):
     # narrow inherited attribute: binary evaluators always carry a BinaryTargetRate
     # (enforced by _init_target_rate).
     target_rate: BinaryTargetRate
+    # narrow inherited `sort_by: str | None`: concrete binary subclasses
+    # (TschuprowtCombinations, CramervCombinations) always set this to a str.
+    sort_by: str
 
     def _init_target_rate(self, target_rate: TargetRate[pd.DataFrame] | None) -> BinaryTargetRate:
         """Initializes target rate."""
@@ -193,6 +199,191 @@ class BinaryCombinationEvaluator(CombinationEvaluator[pd.DataFrame], ABC):
                 n_mod=n_mod,
                 tol=tol,
             )
+
+    def _get_best_combination_non_nan(self) -> dict | None:
+        """DP-based override with progressive top-K.
+
+        Replaces ``consecutive_combinations + _compute_associations`` with the
+        interval-DP in :func:`_top_k_partitions_chi2_dp`, which returns the
+        top-K consecutive partitions ranked by ``self.sort_by`` desc.
+
+        **Progressive search.** Starts with ``top_k = self.dp_top_k_initial``.
+        If the viability walk doesn't find a viable candidate within that
+        top-K, doubles ``top_k`` and re-runs DP — walking only the new
+        entries from where we left off. Repeats until either a viable is
+        found or DP exhausts every consecutive partition (signalled by
+        ``len(result) < top_k``). Total work bounded by ~2× a single DP run
+        at the final top_k.
+
+        This makes the search **exhaustive in the worst case**, matching the
+        legacy enumerate-and-score path's correctness while keeping the
+        common case (viable found in top ~100) essentially free. Mirrors
+        :meth:`ContinuousCombinationEvaluator._get_best_combination_non_nan`.
+
+        The NaN-fan-out path (:meth:`_get_best_combination_with_nan`) still
+        goes through the legacy enumerate-and-score loop.
+        """
+        feature_labels = self.feature.labels
+        if feature_labels is None:
+            raise RuntimeError(f"[{self.__name__}] feature labels are not populated")
+        raw_labels = GroupedList(feature_labels[:])
+
+        if self.feature.has_nan:
+            if self.feature.dropna:
+                raw_labels.remove(self.feature.nan)
+            self.samples.dropna(self.feature.nan)
+
+        if self.samples.train.shape[0] <= 1:
+            return None
+
+        self._historize_raw_combination()
+
+        # Iterate over raw_labels (mirrors the parent's
+        # ``consecutive_combinations(raw_labels, ...)`` enumeration). When
+        # raw_labels and raw_xagg.index diverge (edge-case fixtures with
+        # has_nan=False + nan row in xagg, or has_nan=True/dropna=False),
+        # rows present in raw_xagg but not in raw_labels are excluded; labels
+        # present in raw_labels but not in raw_xagg get zero counts — matching
+        # the legacy ``_grouper``'s ``groupby.get(idx, idx)`` semantics where
+        # an unmapped row produces no contribution.
+        raw_xagg = self.samples.train.xagg
+        all_n0 = raw_xagg.iloc[:, 0].to_numpy(dtype=float)
+        all_n1 = raw_xagg.iloc[:, 1].to_numpy(dtype=float)
+        xagg_pos = {m: i for i, m in enumerate(raw_xagg.index)}
+        raw_index = list(raw_labels)
+        n0_per_mod = np.fromiter(
+            (all_n0[xagg_pos[m]] if m in xagg_pos else 0.0 for m in raw_index),
+            dtype=float,
+            count=len(raw_index),
+        )
+        n1_per_mod = np.fromiter(
+            (all_n1[xagg_pos[m]] if m in xagg_pos else 0.0 for m in raw_index),
+            dtype=float,
+            count=len(raw_index),
+        )
+
+        # Progressive top-K with doubling. See docstring.
+        top_k = self.dp_top_k_initial
+        walked = 0
+        viable: dict | None = None
+        associations: list[dict] = []
+        while True:
+            associations = _top_k_partitions_chi2_dp(
+                n0_per_mod,
+                n1_per_mod,
+                max_n_mod=self.max_n_mod,
+                raw_index=raw_index,
+                sort_by=self.sort_by,
+                top_k=top_k,
+            )
+            viable, walked = self._walk_for_viable(associations, start=walked)
+            if viable is not None:
+                break
+            if walked < top_k:
+                break  # DP exhausted every consecutive partition; no viable exists
+            top_k *= 2
+
+        self._apply_best_combination(viable)
+        return viable
+
+    def _get_best_combination_with_nan(self, best_combination: dict | None) -> dict | None:
+        """DP-based override with NaN fan-out.
+
+        Mirrors :meth:`ContinuousCombinationEvaluator._get_best_combination_with_nan`:
+
+        1. DP top-K base consecutive partitions over the non-nan labels
+           (:func:`_top_k_partitions_chi2_dp` on a restricted view of the
+           per-modality ``(n0, n1)`` counts);
+        2. fan each base out across NaN placements exactly like
+           :func:`nan_combinations` (nan folded into each group, then nan
+           as its own group when ``len(base) < max_n_mod``, plus the final
+           ``[all_non_nan, [nan]]`` partition);
+        3. re-score every variant in closed form with
+           :func:`_chi2_assoc_for_combination` against the **full** per-modality
+           counts (the nan row is in ``samples.train.xagg`` because
+           :meth:`_get_best_combination_non_nan`'s ``_apply_best_combination``
+           rebuilt it from raw);
+        4. walk the sorted variants for the first viable, with progressive
+           top-K doubling on the base DP — dedup'd via a per-partition seen
+           set so combinations carried over from a smaller ``top_k`` are not
+           re-tested / re-historized.
+
+        Falls back to the parent implementation when the guard condition
+        (``self.dropna and feature.has_nan and best_combination is not None``)
+        is not met — matches the legacy short-circuit behaviour.
+        """
+        if not (self.dropna and self.feature.has_nan and best_combination is not None):
+            return super()._get_best_combination_with_nan(best_combination)
+
+        if self.verbose:
+            print(f"[{self.__name__}] Grouping NaNs")
+
+        feature_labels = self.feature.labels
+        if feature_labels is None:
+            raise RuntimeError(f"[{self.__name__}] feature labels are not populated")
+        raw_labels = GroupedList(feature_labels[:])
+        raw_labels.remove(self.feature.nan)
+        nan_label = self.feature.nan
+
+        # Full per-modality (n0, n1) — nan row is in xagg because
+        # _apply_best_combination on the non-nan winner rebuilt it from raw.
+        raw_xagg = self.samples.train.xagg
+        n0_per_mod = raw_xagg.iloc[:, 0].to_numpy(dtype=float)
+        n1_per_mod = raw_xagg.iloc[:, 1].to_numpy(dtype=float)
+        n_obs = float(n0_per_mod.sum() + n1_per_mod.sum())
+        mod_to_pos: dict = {m: i for i, m in enumerate(raw_xagg.index)}
+        n_mod = len(mod_to_pos)
+        tol = 1e-10
+
+        # Non-nan subset, aligned to raw_labels order, for the base DP.
+        non_nan_index = list(raw_labels)
+        n0_non_nan = np.fromiter(
+            (n0_per_mod[mod_to_pos[m]] for m in non_nan_index),
+            dtype=float,
+            count=len(non_nan_index),
+        )
+        n1_non_nan = np.fromiter(
+            (n1_per_mod[mod_to_pos[m]] for m in non_nan_index),
+            dtype=float,
+            count=len(non_nan_index),
+        )
+
+        historized: set[tuple] = set()
+        base_top_k = self.dp_top_k_initial
+        viable: dict | None = None
+
+        while True:
+            base_partitions = _top_k_partitions_chi2_dp(
+                n0_non_nan,
+                n1_non_nan,
+                max_n_mod=self.max_n_mod,
+                raw_index=non_nan_index,
+                sort_by=self.sort_by,
+                top_k=base_top_k,
+                tol=tol,
+            )
+            scored = _score_nan_variants_chi2(
+                base_partitions=base_partitions,
+                nan_label=nan_label,
+                raw_labels=non_nan_index,
+                max_n_mod=self.max_n_mod,
+                n0_per_mod=n0_per_mod,
+                n1_per_mod=n1_per_mod,
+                n_obs=n_obs,
+                mod_to_pos=mod_to_pos,
+                n_mod=n_mod,
+                tol=tol,
+                sort_by=self.sort_by,
+            )
+            viable = self._walk_nan_variants(scored, historized)
+            if viable is not None:
+                break
+            if len(base_partitions) < base_top_k:
+                break  # DP exhausted every consecutive partition
+            base_top_k *= 2
+
+        self._apply_best_combination(viable)
+        return viable
 
 
 class TschuprowtCombinations(BinaryCombinationEvaluator):
@@ -408,3 +599,179 @@ def _chi2_assoc_batch(
             "cramerv": float(cramerv_q[b]),
             "tschuprowt": float(tt_q[b]),
         }
+
+
+def _top_k_partitions_chi2_dp(  # noqa: C901
+    n0_per_mod: np.ndarray,
+    n1_per_mod: np.ndarray,
+    *,
+    max_n_mod: int,
+    raw_index: list,
+    sort_by: str = "tschuprowt",
+    top_k: int = 1000,
+    tol: float = 1e-10,
+) -> list[dict]:
+    """Top-K consecutive-segmentation partitions ranked by a chi²-derived metric.
+
+    Binary analogue of
+    :func:`AutoCarver.combinations.continuous.continuous_combination_evaluators._top_k_partitions_kruskal_dp`.
+
+    The per-segment chi² cell contribution
+
+    .. math::
+
+        c_g = (n_{0,g} + \\tau - E_{0,g})^2 / E_{0,g}
+              + (n_{1,g} + \\tau - E_{1,g})^2 / E_{1,g}
+
+    (with Yates correction iff the combination has exactly 2 groups) is
+    additive across groups **given a fixed number of groups k**: the column
+    marginals ``C[c] = N_c + k·τ`` and total ``N = N₀ + N₁ + 2k·τ`` depend
+    only on ``k``, not on the split positions. So we run a separate interval-DP
+    per ``k ∈ [2, K]`` and merge.
+
+    Returns a list of ``{combination, index_to_groupby, cramerv, tschuprowt}``
+    sorted by ``sort_by`` desc — mirrors the yield shape of
+    :meth:`_compute_associations` so it drops into the streaming pipeline.
+
+    Complexity: O(K² · n_mod² · top_k · log top_k). Independent of the
+    combination count (which can reach ~8 M at ``n_mod=40, max_n_mod=7``).
+
+    Edge cases (mirror :func:`_chi2_assoc_for_combination`):
+
+    * ``max_n_mod < 2`` or ``n_mod < 2``: returns ``[]``.
+    * ``sort_by`` must be ``"cramerv"`` or ``"tschuprowt"``.
+    """
+    if sort_by not in ("cramerv", "tschuprowt"):
+        raise ValueError(f"sort_by must be 'cramerv' or 'tschuprowt', got {sort_by!r}")
+
+    n_mod = len(raw_index)
+    K = min(max_n_mod, n_mod)
+    if K < 2:
+        return []
+
+    n0_prefix = np.concatenate([[0.0], np.cumsum(n0_per_mod.astype(np.float64))])
+    n1_prefix = np.concatenate([[0.0], np.cumsum(n1_per_mod.astype(np.float64))])
+    N0_total = float(n0_prefix[-1])
+    N1_total = float(n1_prefix[-1])
+    n_obs = N0_total + N1_total
+
+    # Collected across all k: (sort_key, cramerv_q, tschuprowt_q, splits)
+    all_entries: list[tuple[float, float, float, tuple[int, ...]]] = []
+
+    for k_groups in range(2, K + 1):
+        C0 = N0_total + k_groups * tol
+        C1 = N1_total + k_groups * tol
+        N_with_tol = N0_total + N1_total + 2.0 * k_groups * tol
+        yates = k_groups == 2
+
+        def seg_cost(
+            i: int, j: int, _C0: float = C0, _C1: float = C1, _N: float = N_with_tol, _yates: bool = yates
+        ) -> float:
+            obs0 = (n0_prefix[j] - n0_prefix[i]) + tol
+            obs1 = (n1_prefix[j] - n1_prefix[i]) + tol
+            R = obs0 + obs1
+            E0 = R * _C0 / _N
+            E1 = R * _C1 / _N
+            if _yates:
+                d0 = E0 - obs0
+                d1 = E1 - obs1
+                obs0 = obs0 + (1.0 if d0 > 0 else (-1.0 if d0 < 0 else 0.0)) * min(0.5, abs(d0))
+                obs1 = obs1 + (1.0 if d1 > 0 else (-1.0 if d1 < 0 else 0.0)) * min(0.5, abs(d1))
+            return (obs0 - E0) ** 2 / E0 + (obs1 - E1) ** 2 / E1
+
+        # dp[g][j] holds up to ``top_k`` (chi2_partial, splits_tuple) pairs sorted
+        # desc, where splits_tuple = (0, s_1, ..., s_{g-1}, j). g = number of
+        # groups in the prefix, j = right boundary.
+        dp: list[list[list[tuple[float, tuple[int, ...]]]]] = [
+            [[] for _ in range(n_mod + 1)] for _ in range(k_groups + 1)
+        ]
+        for j in range(1, n_mod + 1):
+            dp[1][j] = [(seg_cost(0, j), (0, j))]
+        for g in range(2, k_groups + 1):
+            for j in range(g, n_mod + 1):
+                candidates: list[tuple[float, tuple[int, ...]]] = []
+                for i in range(g - 1, j):
+                    c = seg_cost(i, j)
+                    for prev_s, prev_splits in dp[g - 1][i]:
+                        candidates.append((prev_s + c, prev_splits + (j,)))
+                if candidates:
+                    candidates.sort(key=lambda x: x[0], reverse=True)
+                    dp[g][j] = candidates[:top_k]
+
+        # Translate chi² → cramerv (quantised) → tschuprowt (quantised). Matches
+        # :func:`_chi2_assoc_for_combination` cell-for-cell.
+        denom = (k_groups - 1) ** 0.25  # k_groups ≥ 2 here, so denom > 0
+        for chi2, splits in dp[k_groups][n_mod]:
+            cramerv_raw = (chi2 / n_obs) ** 0.5
+            cramerv_q = round(cramerv_raw / tol) * tol
+            tt_raw = cramerv_q / denom
+            tt_q = round(tt_raw / tol) * tol
+            sort_key = tt_q if sort_by == "tschuprowt" else cramerv_q
+            all_entries.append((sort_key, cramerv_q, tt_q, splits))
+
+    all_entries.sort(key=lambda x: x[0], reverse=True)
+    all_entries = all_entries[:top_k]
+
+    out: list[dict] = []
+    for _, cv, tt, splits in all_entries:
+        combination = [list(raw_index[splits[g] : splits[g + 1]]) for g in range(len(splits) - 1)]
+        out.append(
+            {
+                "combination": combination,
+                "index_to_groupby": combination_formatter(combination),
+                "cramerv": float(cv),
+                "tschuprowt": float(tt),
+            }
+        )
+    return out
+
+
+def _score_nan_variants_chi2(
+    *,
+    base_partitions: list[dict],
+    nan_label: str,
+    raw_labels: list,
+    max_n_mod: int,
+    n0_per_mod: np.ndarray,
+    n1_per_mod: np.ndarray,
+    n_obs: float,
+    mod_to_pos: dict,
+    n_mod: int,
+    tol: float,
+    sort_by: str,
+) -> list[dict]:
+    """Score every NaN-fanout variant via closed-form chi² (Cramér's V +
+    Tschuprow's T), sorted by ``sort_by`` desc.
+
+    Uses :func:`_chi2_assoc_for_combination` per variant — bit-identical to
+    the legacy ``chi2_contingency`` path on the per-variant crosstab.
+    """
+    scored: list[dict] = []
+    for variant in _nan_fanout_variants(base_partitions, nan_label, raw_labels, max_n_mod):
+        index_to_groupby = combination_formatter(variant)
+        cv, tt = _chi2_assoc_for_combination(
+            n0_per_mod=n0_per_mod,
+            n1_per_mod=n1_per_mod,
+            n_obs=n_obs,
+            mod_to_pos=mod_to_pos,
+            n_mod=n_mod,
+            index_to_groupby=index_to_groupby,
+            tol=tol,
+        )
+        scored.append(
+            {
+                "combination": variant,
+                "index_to_groupby": index_to_groupby,
+                "cramerv": cv,
+                "tschuprowt": tt,
+            }
+        )
+
+    def _key(a: dict) -> float:
+        v = a[sort_by]
+        if v is None or (isinstance(v, float) and math.isnan(v)):
+            return float("-inf")
+        return float(v)
+
+    scored.sort(key=_key, reverse=True)
+    return scored

--- a/AutoCarver/combinations/continuous/continuous_combination_evaluators.py
+++ b/AutoCarver/combinations/continuous/continuous_combination_evaluators.py
@@ -1,5 +1,6 @@
 """Module for continuous combination evaluators."""
 
+import math
 from abc import ABC
 from collections.abc import Iterable, Iterator
 from typing import Any
@@ -10,10 +11,15 @@ from scipy.stats import kruskal, rankdata, tiecorrect
 from tqdm import tqdm
 
 from AutoCarver.combinations.continuous.continuous_target_rates import ContinuousTargetRate, TargetMean, TargetMedian
-from AutoCarver.combinations.utils.combination_evaluator import AggregatedSample, CombinationEvaluator
+from AutoCarver.combinations.utils.combination_evaluator import (
+    AggregatedSample,
+    CombinationEvaluator,
+    _nan_fanout_variants,
+)
 from AutoCarver.combinations.utils.combinations import combination_formatter
 from AutoCarver.combinations.utils.target_rate import TargetRate
 from AutoCarver.combinations.utils.testing import Keys, is_viable, test_viability
+from AutoCarver.features import GroupedList
 
 
 class ContinuousCombinationEvaluator(CombinationEvaluator[pd.Series], ABC):
@@ -243,6 +249,206 @@ class ContinuousCombinationEvaluator(CombinationEvaluator[pd.Series], ABC):
                 return test_viability(train_rates, self.min_freq, self.target_rate.__name__)
         # Fallback: legacy grouper + apply(np.mean/median) over Python lists
         return super()._test_viability_train(combination)
+
+    def _get_best_combination_non_nan(self) -> dict | None:
+        """DP-based override with progressive top-K.
+
+        Replaces ``consecutive_combinations + _compute_associations`` with the
+        interval-DP in :func:`_top_k_partitions_kruskal_dp`, which returns the
+        top-K consecutive partitions ranked by Kruskal-Wallis H descending.
+
+        **Progressive search.** Starts with ``top_k = self.dp_top_k_initial``.
+        If the viability walk doesn't find a viable candidate within that top-K,
+        doubles top_k and re-runs DP — walking only the new entries from where
+        we left off. Repeats until either a viable is found or DP exhausts
+        every consecutive partition (signalled by ``len(result) < top_k``).
+        Total work bounded by ~2× a single DP run at the final top_k.
+
+        This makes the search **exhaustive in the worst case**, matching the
+        legacy enumerate-and-score path's correctness while keeping the common
+        case (viable found in top ~100) essentially free.
+
+        The NaN-fan-out path (:meth:`_get_best_combination_with_nan`) still
+        goes through the legacy enumerate-and-score loop — handled in §8.3.
+        """
+        feature_labels = self.feature.labels
+        if feature_labels is None:
+            raise RuntimeError(f"[{self.__name__}] feature labels are not populated")
+        raw_labels = GroupedList(feature_labels[:])
+
+        if self.feature.has_nan:
+            if self.feature.dropna:
+                raw_labels.remove(self.feature.nan)
+            self.samples.dropna(self.feature.nan)
+
+        if self.samples.train.shape[0] <= 1:
+            return None
+
+        self._historize_raw_combination()
+
+        # Pre-rank y once for the whole feature (same as _compute_associations).
+        raw_xagg = self.samples.train.xagg
+        R_per_mod, n_per_mod, N, tie_corr = _modality_rank_stats(raw_xagg)  # type: ignore
+        sum_y_per_mod = _modality_sum_y(raw_xagg)  # type: ignore
+        mod_to_pos: dict = {m: i for i, m in enumerate(raw_xagg.index)}
+        n_mod = len(mod_to_pos)
+        raw_index = list(raw_xagg.index)
+
+        # Cache for viability fast path (mirrors _compute_associations).
+        self._train_modality_stats: dict[str, Any] = {
+            "n_per_mod": n_per_mod.astype(float),
+            "sum_y_per_mod": sum_y_per_mod,
+            "mod_to_pos": mod_to_pos,
+            "n_mod": n_mod,
+        }
+        self._dev_modality_stats: dict[str, Any] | None = None
+        self._dev_modality_stats_id: int | None = None
+
+        # Progressive top-K with doubling. See docstring.
+        top_k = self.dp_top_k_initial
+        walked = 0
+        viable: dict | None = None
+        associations: list[dict] = []
+        while True:
+            associations = _top_k_partitions_kruskal_dp(
+                R_per_mod,
+                n_per_mod,
+                N,
+                tie_corr,
+                max_n_mod=self.max_n_mod,
+                raw_index=raw_index,
+                top_k=top_k,
+            )
+            viable, walked = self._walk_for_viable(associations, start=walked)
+            if viable is not None:
+                break
+            if walked < top_k:
+                break  # DP exhausted every consecutive partition; no viable exists
+            top_k *= 2
+
+        # Rebuild grouped xagg for the winner (fast path skipped this).
+        if viable is not None and viable.get("xagg") is None:
+            index_to_groupby = viable.get("index_to_groupby") or combination_formatter(viable["combination"])
+            viable["xagg"] = self._grouper(self.samples.train, index_to_groupby)
+
+        self._apply_best_combination(viable)
+        return viable
+
+    def _get_best_combination_with_nan(self, best_combination: dict | None) -> dict | None:
+        """DP-based override with NaN fan-out.
+
+        Replaces ``nan_combinations + _get_best_association`` with:
+
+        1. DP top-K base consecutive partitions over the non-nan labels
+           (:func:`_top_k_partitions_kruskal_dp` on a restricted view of
+           the per-modality stats);
+        2. fan each base out across NaN placements exactly like
+           :func:`nan_combinations` (nan folded into each group, then nan
+           as its own group when ``len(base) < max_n_mod``, plus the final
+           ``[all_non_nan, [nan]]`` partition);
+        3. re-score every variant in closed form with
+           :func:`_kruskal_h_for_combination` against the **full** per-modality
+           stats (the nan row is included because :meth:`_get_best_combination_non_nan`'s
+           ``_apply_best_combination`` repopulates ``samples.train.xagg`` with
+           the nan modality intact);
+        4. walk the sorted variants for the first viable, with progressive
+           top-K doubling on the base DP — dedup'd via a per-partition seen
+           set so combinations carried over from a smaller ``top_k`` are not
+           re-tested / re-historized.
+
+        Falls back to the parent implementation when the guard condition
+        (``self.dropna and feature.has_nan and best_combination is not None``)
+        is not met — matches the legacy short-circuit behaviour.
+        """
+        if not (self.dropna and self.feature.has_nan and best_combination is not None):
+            return super()._get_best_combination_with_nan(best_combination)
+
+        if self.verbose:
+            print(f"[{self.__name__}] Grouping NaNs")
+
+        feature_labels = self.feature.labels
+        if feature_labels is None:
+            raise RuntimeError(f"[{self.__name__}] feature labels are not populated")
+        raw_labels = GroupedList(feature_labels[:])
+        raw_labels.remove(self.feature.nan)
+        nan_label = self.feature.nan
+
+        # Full per-modality stats — the nan row is still in xagg because
+        # _apply_best_combination on the non-nan winner rebuilt it from raw.
+        raw_xagg = self.samples.train.xagg
+        R_per_mod, n_per_mod, N, tie_corr = _modality_rank_stats(raw_xagg)  # type: ignore
+        if R_per_mod is None or tie_corr is None or tie_corr == 0:
+            # Degenerate cases (N<2 or all-identical y): legacy path returns
+            # NaN/None scores and walks them anyway. Defer to it for parity.
+            return super()._get_best_combination_with_nan(best_combination)
+
+        sum_y_per_mod = _modality_sum_y(raw_xagg)  # type: ignore
+        mod_to_pos: dict = {m: i for i, m in enumerate(raw_xagg.index)}
+        n_mod = len(mod_to_pos)
+
+        # Refresh viability fast-path cache to the with-nan stats.
+        self._train_modality_stats: dict[str, Any] = {
+            "n_per_mod": n_per_mod.astype(float),
+            "sum_y_per_mod": sum_y_per_mod,
+            "mod_to_pos": mod_to_pos,
+            "n_mod": n_mod,
+        }
+        self._dev_modality_stats: dict[str, Any] | None = None
+        self._dev_modality_stats_id: int | None = None
+
+        # Non-nan subset, aligned to raw_labels order, for the base DP.
+        non_nan_index = list(raw_labels)
+        R_non_nan = np.fromiter(
+            (R_per_mod[mod_to_pos[m]] for m in non_nan_index),
+            dtype=float,
+            count=len(non_nan_index),
+        )
+        n_non_nan = np.fromiter(
+            (n_per_mod[mod_to_pos[m]] for m in non_nan_index),
+            dtype=float,
+            count=len(non_nan_index),
+        )
+        N_non_nan = int(n_non_nan.sum())
+
+        historized: set[tuple] = set()
+        base_top_k = self.dp_top_k_initial
+        viable: dict | None = None
+
+        while True:
+            base_partitions = _top_k_partitions_kruskal_dp(
+                R_non_nan,
+                n_non_nan,
+                N_non_nan,
+                tie_corr,
+                max_n_mod=self.max_n_mod,
+                raw_index=non_nan_index,
+                top_k=base_top_k,
+            )
+            scored = _score_nan_variants_kruskal(
+                base_partitions=base_partitions,
+                nan_label=nan_label,
+                raw_labels=non_nan_index,
+                max_n_mod=self.max_n_mod,
+                R_per_mod=R_per_mod,
+                n_per_mod=n_per_mod,
+                N=N,
+                tie_corr=tie_corr,
+                mod_to_pos=mod_to_pos,
+                n_mod=n_mod,
+            )
+            viable = self._walk_nan_variants(scored, historized)
+            if viable is not None:
+                break
+            if len(base_partitions) < base_top_k:
+                break  # DP exhausted every consecutive partition
+            base_top_k *= 2
+
+        if viable is not None and viable.get("xagg") is None:
+            index_to_groupby = viable.get("index_to_groupby") or combination_formatter(viable["combination"])
+            viable["xagg"] = self._grouper(self.samples.train, index_to_groupby)
+
+        self._apply_best_combination(viable)
+        return viable
 
     def _get_viable_combination(self, associations: list[dict]) -> dict | None:
         """Walks associations under the fast viability path and materialises
@@ -522,3 +728,155 @@ def _kruskal_h_batch(  # noqa: C901
             "index_to_groupby": item["index_to_groupby"],
             "kruskal": h_val,
         }
+
+
+def _top_k_partitions_kruskal_dp(  # noqa: C901
+    R_per_mod: np.ndarray | None,
+    n_per_mod: np.ndarray,
+    N: int,
+    tie_corr: float | None,
+    *,
+    max_n_mod: int,
+    raw_index: list,
+    top_k: int = 1000,
+) -> list[dict]:
+    """Top-K consecutive-segmentation partitions ranked by Kruskal-Wallis H.
+
+    Replaces enumerate-and-score with an interval-DP that exploits two facts:
+
+    1. ``consecutive_combinations`` only emits segmentations of ``raw_index``
+       (no out-of-order groupings) — a combination is fully determined by
+       integer split positions ``0 = s_0 < ... < s_k = n_mod``.
+    2. Kruskal-Wallis H is additively decomposable across groups:
+       ``ssbn = Σ_g R_g² / n_g`` where ``R_g`` and ``n_g`` are obtained in
+       O(1) from prefix sums.
+
+    Complexity: O(K · n_mod² · top_k · log top_k). At ``n_mod = 40,
+    max_n_mod = 7, top_k = 1000`` that's ~5.6 M ops — independent of the
+    combination count (which can reach ~8 M at the same n_mod / max_n_mod).
+
+    Returns a list of ``{combination, index_to_groupby, kruskal}`` dicts
+    sorted by ``kruskal`` desc. Mirrors the shape ``_compute_associations``
+    currently yields, so it can be dropped into the streaming pipeline.
+
+    Edge cases (mirror :func:`_kruskal_h_for_combination`):
+    * ``R_per_mod is None`` or ``N < 2`` or ``tie_corr is None or == 0``:
+      returns ``[]`` (caller treats as "no scorable combinations").
+    * Empty-modality segments (``Σ n_per_mod[i:j] == 0``) are excluded
+      (they would otherwise produce ``nan`` H and lose to any non-empty
+      partition in the sort anyway).
+    """
+    if R_per_mod is None or N < 2 or tie_corr is None or tie_corr == 0:
+        return []
+
+    n_mod = len(raw_index)
+    K = min(max_n_mod, n_mod)
+    if K < 2:
+        return []
+
+    R_prefix = np.concatenate([[0.0], np.cumsum(R_per_mod.astype(np.float64))])
+    n_prefix = np.concatenate([[0.0], np.cumsum(n_per_mod.astype(np.float64))])
+
+    def seg_cost(i: int, j: int) -> float:
+        nn = n_prefix[j] - n_prefix[i]
+        if nn <= 0:
+            return float("-inf")  # empty segment — exclude
+        r = R_prefix[j] - R_prefix[i]
+        return (r * r) / nn
+
+    # dp[k][j] holds up to ``top_k`` (S_total, splits_tuple) pairs sorted by
+    # S_total desc, where splits_tuple = (0, s_1, ..., s_{k-1}, j).
+    # k = number of groups, j = right boundary of the partition prefix.
+    dp: list[list[list[tuple[float, tuple[int, ...]]]]] = [[[] for _ in range(n_mod + 1)] for _ in range(K + 1)]
+
+    # Base case: a single group covering [0, j].
+    for j in range(1, n_mod + 1):
+        c = seg_cost(0, j)
+        if c != float("-inf"):
+            dp[1][j] = [(c, (0, j))]
+
+    # Recurrence: dp[k][j] = best top_k of  dp[k-1][i] + seg_cost(i, j)  over i.
+    for k in range(2, K + 1):
+        for j in range(k, n_mod + 1):
+            candidates: list[tuple[float, tuple[int, ...]]] = []
+            for i in range(k - 1, j):
+                c = seg_cost(i, j)
+                if c == float("-inf"):
+                    continue
+                for prev_s, prev_splits in dp[k - 1][i]:
+                    candidates.append((prev_s + c, prev_splits + (j,)))
+            if candidates:
+                candidates.sort(key=lambda x: x[0], reverse=True)
+                dp[k][j] = candidates[:top_k]
+
+    # Collect full-coverage partitions for each k ∈ [2, K], translate ssbn → H.
+    coef = 12.0 / (N * (N + 1))
+    offset = 3.0 * (N + 1)
+    final: list[tuple[float, tuple[int, ...]]] = []
+    for k in range(2, K + 1):
+        for s, splits in dp[k][n_mod]:
+            h = (coef * s - offset) / tie_corr
+            final.append((h, splits))
+    final.sort(key=lambda x: x[0], reverse=True)
+    final = final[:top_k]
+
+    out: list[dict] = []
+    for h, splits in final:
+        combination = [list(raw_index[splits[g] : splits[g + 1]]) for g in range(len(splits) - 1)]
+        out.append(
+            {
+                "combination": combination,
+                "index_to_groupby": combination_formatter(combination),
+                "kruskal": float(h),
+            }
+        )
+    return out
+
+
+def _score_nan_variants_kruskal(
+    *,
+    base_partitions: list[dict],
+    nan_label: str,
+    raw_labels: list,
+    max_n_mod: int,
+    R_per_mod: np.ndarray,
+    n_per_mod: np.ndarray,
+    N: int,
+    tie_corr: float,
+    mod_to_pos: dict,
+    n_mod: int,
+) -> list[dict]:
+    """Score every NaN-fanout variant via closed-form Kruskal H, sorted desc.
+
+    Uses :func:`_kruskal_h_for_combination` per variant (O(k) per call),
+    which is plenty fast for the ~top_k * (max_n_mod + 1) + 1 variants
+    produced by :func:`_nan_fanout_variants`.
+    """
+    scored: list[dict] = []
+    for variant in _nan_fanout_variants(base_partitions, nan_label, raw_labels, max_n_mod):
+        index_to_groupby = combination_formatter(variant)
+        h = _kruskal_h_for_combination(
+            R_per_mod=R_per_mod,
+            n_per_mod=n_per_mod,
+            N=N,
+            tie_corr=tie_corr,
+            mod_to_pos=mod_to_pos,
+            n_mod=n_mod,
+            index_to_groupby=index_to_groupby,
+        )
+        scored.append(
+            {
+                "combination": variant,
+                "index_to_groupby": index_to_groupby,
+                "kruskal": h,
+            }
+        )
+
+    def _key(a: dict) -> float:
+        v = a["kruskal"]
+        if v is None or (isinstance(v, float) and math.isnan(v)):
+            return float("-inf")
+        return float(v)
+
+    scored.sort(key=_key, reverse=True)
+    return scored

--- a/AutoCarver/combinations/utils/combination_evaluator.py
+++ b/AutoCarver/combinations/utils/combination_evaluator.py
@@ -156,6 +156,15 @@ class CombinationEvaluator(ABC, Generic[XAgg]):
     is_y_continuous = False
     sort_by = None
 
+    # Initial top-K for the DP-based segmentation
+    # path used by the continuous and binary subclasses. The progressive
+    # doubling loop in ``_get_best_combination_non_nan`` / ``_get_best_combination_with_nan``
+    # grows ``top_k`` from this starting point until either a viable candidate
+    # is found or the DP exhausts every consecutive partition — making the
+    # search exhaustive in the worst case while keeping the common case
+    # (viable in top ~100) essentially free.
+    dp_top_k_initial: int = 1000
+
     def __init__(
         self,
         *,
@@ -432,7 +441,7 @@ class CombinationEvaluator(ABC, Generic[XAgg]):
 
         # testing viability of all combinations
         viable_combination = None
-        for n_combination, combination in tqdm(
+        for _n_combination, combination in tqdm(
             enumerate(associations),
             total=len(associations),
             desc="Testing robustness    ",
@@ -450,15 +459,61 @@ class CombinationEvaluator(ABC, Generic[XAgg]):
             # best combination found: breaking the loop on combinations
             if test_results[Keys.VIABLE.value]:
                 viable_combination = combination
-
-                # historizing remaining combinations/not tested
-                self._historize_remaining_combinations(associations, n_combination)
                 break
 
         if self.verbose:  # verbose if requested
             print("\n")
 
         return viable_combination
+
+    def _walk_for_viable(self, associations: list[dict], start: int) -> tuple[dict | None, int]:
+        """Walk ``associations[start:]`` for the first viable combination.
+
+        Inlined version of :meth:`_get_viable_combination` that supports
+        resuming from a checkpoint (``start``) — used by the progressive
+        top-K loop in the subclasses' ``_get_best_combination_non_nan``.
+        ``_test_viability_train`` lazily rebuilds the heavy xagg via
+        ``_grouper`` on first access, so DP entries (which don't carry
+        ``xagg``) work transparently.
+
+        Returns
+        -------
+        (viable, walked) : tuple
+            ``viable`` is the first viable combination found, or ``None``.
+            ``walked`` is the next index to resume from on a follow-up call;
+            equals ``len(associations)`` when no viable was found in this slice.
+        """
+        i = start
+        while i < len(associations):
+            combination = associations[i]
+            test_results = self._test_viability_train(combination)
+            test_results = self._test_viability_dev(test_results, combination)
+            self._historize_combination(combination, test_results)
+            if test_results[Keys.VIABLE.value]:
+                return combination, i + 1
+            i += 1
+        return None, i
+
+    def _walk_nan_variants(self, scored: list[dict], historized: set[tuple]) -> dict | None:
+        """Walk NaN-fanout variants in metric-desc order, dedup'd by partition.
+
+        Used by the subclasses' ``_get_best_combination_with_nan`` after
+        DP top-K base partitions have been fanned out across NaN placements
+        and scored. ``historized`` is updated in place: variants already
+        tested in a previous progressive-top-K iteration are skipped (not
+        re-tested, not re-historized).
+        """
+        for combination in scored:
+            key = _variant_key(combination["combination"])
+            if key in historized:
+                continue
+            historized.add(key)
+            test_results = self._test_viability_train(combination)
+            test_results = self._test_viability_dev(test_results, combination)
+            self._historize_combination(combination, test_results)
+            if test_results[Keys.VIABLE.value]:
+                return combination
+        return None
 
     @abstractmethod
     def _grouper(self, xagg: AggregatedSample, groupby: dict[str, str]) -> XAgg:
@@ -477,14 +532,6 @@ class CombinationEvaluator(ABC, Generic[XAgg]):
         Kruskal–Wallis path (which returns ``None`` when scipy raises) can
         share the base signature with the binary chi² path.
         """
-
-    def _historize_remaining_combinations(self, associations: list[dict], n_combination: int) -> None:
-        """historizes the remaining combinations that have not been tested"""
-
-        # historizing all remaining combinations
-        for combination in associations[n_combination + 1 :]:
-            # historizing not tested combination
-            self.feature.historize({**clean_combination(combination, self.feature), "info": "Not checked"})
 
     def _historize_combination(self, combination: dict, test_results: dict) -> None:
         """historizes the test results of the combination"""
@@ -661,3 +708,40 @@ def clean_combination(combination: dict, feature: BaseFeature, remove_train_rate
     filtered = {k: v for k, v in combination.items() if k not in unwanted_keys}
 
     return {**filtered, "n_mod": n_mod, "dropna": dropna, "combination": index_to_groupby}
+
+
+def _variant_key(combination: list[list]) -> tuple:
+    """Canonical hashable key identifying a (consecutive) combination.
+
+    Used by :meth:`CombinationEvaluator._walk_nan_variants` to skip variants
+    already tested in a previous progressive-top-K iteration. Order matters
+    semantically (``consecutive_combinations`` always preserves raw_index
+    order, and :func:`combination_formatter` picks ``group[0]`` as leader)
+    so a positional tuple-of-tuples is the right shape.
+    """
+    return tuple(tuple(g) for g in combination)
+
+
+def _nan_fanout_variants(
+    base_partitions: list[dict],
+    nan_label: str,
+    raw_labels: list,
+    max_n_mod: int,
+) -> Iterator[list[list]]:
+    """Yields NaN-augmented variants of each base consecutive partition.
+
+    Mirrors :func:`AutoCarver.combinations.utils.combinations.nan_combinations`
+    semantics: for every base combination, fold ``nan_label`` into each group;
+    add it as its own group iff ``len(base) < max_n_mod``; finally yield the
+    ``[list(raw_labels), [nan_label]]`` partition once. Subclass-specific
+    scoring (Kruskal H / chi²) happens in the caller.
+    """
+    for base in base_partitions:
+        base_combo = base["combination"]
+        for j in range(len(base_combo)):
+            variant = [g[:] for g in base_combo]
+            variant[j] = variant[j] + [nan_label]
+            yield variant
+        if len(base_combo) < max_n_mod:
+            yield [g[:] for g in base_combo] + [[nan_label]]
+    yield [list(raw_labels), [nan_label]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AutoCarver"
-version = "7.2.2"
+version = "7.2.5"
 description = "Automatic Discretization of Features with Optimal Target Association"
 authors = [{ name = "Mario DEFRANCE", email = "defrancemario@gmail.com" }]
 requires-python = ">=3.11, <3.15"

--- a/tests/combinations/binary/test_dp_chi2_parity.py
+++ b/tests/combinations/binary/test_dp_chi2_parity.py
@@ -1,0 +1,235 @@
+"""Parity tests for the DP-based top-K chi² segmentation path.
+
+SPEEDUP_PLAN §8.4. ``_top_k_partitions_chi2_dp`` enumerates the K best
+*consecutive segmentations* of raw_index via an interval-DP over prefix sums
+of per-modality ``(n0, n1)`` counts, instead of the current enumerate-then-score
+loop. These tests assert that the DP's Cramér's V / Tschuprow's T values and
+partition shapes match the exhaustive enumeration path
+(``consecutive_combinations`` + ``_chi2_assoc_for_combination``).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from AutoCarver.combinations.binary.binary_combination_evaluators import (
+    _chi2_assoc_for_combination,
+    _top_k_partitions_chi2_dp,
+)
+from AutoCarver.combinations.utils.combinations import (
+    combination_formatter,
+    consecutive_combinations,
+)
+
+TOL = 1e-10
+
+
+def _exhaustive_top_k(
+    xagg: pd.DataFrame,
+    max_n_mod: int,
+    top_k: int,
+    sort_by: str,
+) -> list[tuple[float, float, float, tuple[tuple, ...]]]:
+    """Brute-force: score every combination, keep the top-K by ``sort_by`` desc.
+
+    Returns ``(sort_key, cramerv, tschuprowt, combination_as_tuple_of_tuples)``.
+    """
+    raw_labels = list(xagg.index)
+    n0_per_mod = xagg.iloc[:, 0].to_numpy(dtype=float)
+    n1_per_mod = xagg.iloc[:, 1].to_numpy(dtype=float)
+    n_obs = float(n0_per_mod.sum() + n1_per_mod.sum())
+    mod_to_pos = {m: i for i, m in enumerate(raw_labels)}
+    n_mod = len(raw_labels)
+
+    scored: list[tuple[float, float, float, tuple[tuple, ...]]] = []
+    for combination in consecutive_combinations(raw_labels, max_n_mod):
+        cv, tt = _chi2_assoc_for_combination(
+            n0_per_mod=n0_per_mod,
+            n1_per_mod=n1_per_mod,
+            n_obs=n_obs,
+            mod_to_pos=mod_to_pos,
+            n_mod=n_mod,
+            index_to_groupby=combination_formatter(combination),
+            tol=TOL,
+        )
+        sort_key = tt if sort_by == "tschuprowt" else cv
+        scored.append((float(sort_key), float(cv), float(tt), tuple(tuple(g) for g in combination)))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored[:top_k]
+
+
+def _dp_call(xagg: pd.DataFrame, max_n_mod: int, top_k: int, sort_by: str) -> list[dict]:
+    n0_per_mod = xagg.iloc[:, 0].to_numpy(dtype=float)
+    n1_per_mod = xagg.iloc[:, 1].to_numpy(dtype=float)
+    return _top_k_partitions_chi2_dp(
+        n0_per_mod,
+        n1_per_mod,
+        max_n_mod=max_n_mod,
+        raw_index=list(xagg.index),
+        sort_by=sort_by,
+        top_k=top_k,
+        tol=TOL,
+    )
+
+
+def _random_xagg(rng: np.random.Generator, n_mod: int, low: int = 0, high: int = 30) -> pd.DataFrame:
+    n0 = rng.integers(low, high, size=n_mod)
+    n1 = rng.integers(low, high, size=n_mod)
+    return pd.DataFrame({0: n0, 1: n1}, index=[f"m{i}" for i in range(n_mod)])
+
+
+@pytest.mark.parametrize("sort_by", ["tschuprowt", "cramerv"])
+@pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("n_mod", [3, 5, 7, 10])
+def test_dp_top1_matches_exhaustive(seed: int, n_mod: int, sort_by: str):
+    """DP's single best metric matches exhaustive best on random (n0, n1)."""
+    rng = np.random.default_rng(seed * 100 + n_mod)
+    xagg = _random_xagg(rng, n_mod)
+    max_n_mod = min(7, n_mod)
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=max_n_mod, top_k=10, sort_by=sort_by)
+    dp = _dp_call(xagg, max_n_mod=max_n_mod, top_k=10, sort_by=sort_by)
+
+    assert dp, "DP returned no candidates"
+    assert exhaustive, "exhaustive returned no candidates"
+    # Quantised to TOL=1e-10 in both paths. Float order differs (prefix-sum DP
+    # vs full-matrix bincount), so allow one tol of slack at the quantisation
+    # boundary.
+    dp_val = dp[0]["tschuprowt"] if sort_by == "tschuprowt" else dp[0]["cramerv"]
+    ex_val = exhaustive[0][0]
+    assert math.isclose(dp_val, ex_val, rel_tol=1e-8, abs_tol=2 * TOL), (
+        f"top-1 {sort_by}: DP={dp_val} vs exhaustive={ex_val}"
+    )
+
+
+@pytest.mark.parametrize("sort_by", ["tschuprowt", "cramerv"])
+@pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("n_mod", [3, 5, 7, 10])
+def test_dp_top_k_metric_sequence_matches_exhaustive(seed: int, n_mod: int, sort_by: str):
+    """Top-K *metric values* (modulo ties) match exhaustive enumeration."""
+    rng = np.random.default_rng(seed * 100 + n_mod + 999)
+    xagg = _random_xagg(rng, n_mod)
+    max_n_mod = min(7, n_mod)
+    top_k = 25
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=max_n_mod, top_k=top_k, sort_by=sort_by)
+    dp = _dp_call(xagg, max_n_mod=max_n_mod, top_k=top_k, sort_by=sort_by)
+
+    n_compare = min(len(exhaustive), len(dp))
+    assert n_compare > 0
+    for rank in range(n_compare):
+        dp_val = dp[rank]["tschuprowt"] if sort_by == "tschuprowt" else dp[rank]["cramerv"]
+        ex_val = exhaustive[rank][0]
+        assert math.isclose(dp_val, ex_val, rel_tol=1e-8, abs_tol=2 * TOL), (
+            f"rank {rank} ({sort_by}): DP={dp_val} vs exhaustive={ex_val}"
+        )
+
+    # NOTE: partition-shape equality at rank 0 is *not* asserted. With integer
+    # counts, multiple partitions can be exactly tied on chi² (and hence on
+    # cramerv / tschuprowt after quantisation); tie resolution is
+    # implementation-defined. The metric equality above is the correctness
+    # invariant.
+
+
+@pytest.mark.parametrize("sort_by", ["tschuprowt", "cramerv"])
+@pytest.mark.parametrize("seed", range(5))
+def test_dp_handles_small_counts(seed: int, sort_by: str):
+    """Small / zero counts — the kind of edge case that stresses ``+tol`` shifts."""
+    rng = np.random.default_rng(seed + 4242)
+    n_mod = int(rng.integers(3, 7))
+    xagg = _random_xagg(rng, n_mod, low=0, high=4)
+    max_n_mod = min(5, n_mod)
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=max_n_mod, top_k=5, sort_by=sort_by)
+    dp = _dp_call(xagg, max_n_mod=max_n_mod, top_k=5, sort_by=sort_by)
+
+    if not exhaustive:
+        # Edge: all counts zero → no chi² to compute. DP should also be empty.
+        assert dp == []
+        return
+
+    assert dp, "DP returned no candidates"
+    dp_val = dp[0]["tschuprowt"] if sort_by == "tschuprowt" else dp[0]["cramerv"]
+    ex_val = exhaustive[0][0]
+    assert math.isclose(dp_val, ex_val, rel_tol=1e-8, abs_tol=2 * TOL)
+
+
+def test_dp_returns_empty_when_n_mod_below_two():
+    xagg = pd.DataFrame({0: [3], 1: [5]}, index=["a"])
+    assert _dp_call(xagg, max_n_mod=2, top_k=10, sort_by="tschuprowt") == []
+    assert _dp_call(xagg, max_n_mod=2, top_k=10, sort_by="cramerv") == []
+
+
+def test_dp_returns_empty_when_max_n_mod_below_two():
+    xagg = pd.DataFrame({0: [3, 1, 4], 1: [5, 2, 6]}, index=["a", "b", "c"])
+    assert _dp_call(xagg, max_n_mod=1, top_k=10, sort_by="tschuprowt") == []
+
+
+def test_dp_rejects_invalid_sort_by():
+    xagg = pd.DataFrame({0: [3, 1, 4], 1: [5, 2, 6]}, index=["a", "b", "c"])
+    with pytest.raises(ValueError, match="sort_by"):
+        _dp_call(xagg, max_n_mod=3, top_k=10, sort_by="not_a_metric")
+
+
+def test_dp_index_to_groupby_matches_combination_formatter():
+    """``index_to_groupby`` in DP output must equal
+    ``combination_formatter(combination)`` so downstream viability tests work
+    unchanged."""
+    rng = np.random.default_rng(0)
+    xagg = _random_xagg(rng, 6)
+    result = _dp_call(xagg, max_n_mod=4, top_k=20, sort_by="tschuprowt")
+    for entry in result:
+        assert entry["index_to_groupby"] == combination_formatter(entry["combination"])
+
+
+@pytest.mark.parametrize("sort_by", ["tschuprowt", "cramerv"])
+def test_dp_output_is_sorted_desc_by_metric(sort_by: str):
+    rng = np.random.default_rng(7)
+    xagg = _random_xagg(rng, 7)
+    result = _dp_call(xagg, max_n_mod=5, top_k=30, sort_by=sort_by)
+    values = [e[sort_by] for e in result]
+    assert values == sorted(values, reverse=True)
+
+
+def test_dp_partition_is_consecutive_segmentation():
+    """Every returned combination must be a *consecutive* segmentation of
+    ``raw_index`` (no out-of-order groupings, matching the structural
+    invariant of ``consecutive_combinations``).
+    """
+    rng = np.random.default_rng(11)
+    xagg = _random_xagg(rng, 6)
+    raw_index = list(xagg.index)
+    result = _dp_call(xagg, max_n_mod=5, top_k=20, sort_by="tschuprowt")
+    for entry in result:
+        flat = [m for group in entry["combination"] for m in group]
+        # flat must be a contiguous slice of raw_index from position 0
+        assert flat == raw_index[: len(flat)], (
+            f"non-consecutive partition: {entry['combination']} vs raw_index={raw_index}"
+        )
+
+
+def test_dp_yates_correction_path_matches_exhaustive():
+    """The k=2 branch of the DP applies Yates correction; the k>=3 branches
+    do not. This test pins that the Yates branch produces the same chi² as
+    the exhaustive path on a 2-group partition.
+    """
+    # Picking n_mod=4 so we get a mix of k=2 (Yates) and k=3,4 (no Yates) partitions.
+    rng = np.random.default_rng(2026)
+    xagg = _random_xagg(rng, 4, low=1, high=20)
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=4, top_k=50, sort_by="cramerv")
+    dp = _dp_call(xagg, max_n_mod=4, top_k=50, sort_by="cramerv")
+
+    # Compare every rank — covers both Yates and non-Yates cells.
+    n_compare = min(len(exhaustive), len(dp))
+    for rank in range(n_compare):
+        assert math.isclose(dp[rank]["cramerv"], exhaustive[rank][1], rel_tol=1e-8, abs_tol=2 * TOL), (
+            f"rank {rank} cramerv mismatch"
+        )
+        assert math.isclose(dp[rank]["tschuprowt"], exhaustive[rank][2], rel_tol=1e-8, abs_tol=2 * TOL), (
+            f"rank {rank} tschuprowt mismatch"
+        )

--- a/tests/combinations/binary/test_dp_progressive_top_k_binary.py
+++ b/tests/combinations/binary/test_dp_progressive_top_k_binary.py
@@ -1,0 +1,133 @@
+"""Tests for the progressive top-K doubling loop in
+:meth:`BinaryCombinationEvaluator._get_best_combination_non_nan`.
+
+SPEEDUP_PLAN §8.4. When the viable winner sits past ``dp_top_k_initial``,
+the DP must grow ``top_k`` (doubling each round) and keep walking until a
+viable candidate is found or every consecutive partition is exhausted.
+These tests pin that contract — mirrors
+``tests/combinations/continuous/test_dp_progressive_top_k.py``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from AutoCarver.combinations.binary.binary_combination_evaluators import (
+    CramervCombinations,
+    TschuprowtCombinations,
+)
+from AutoCarver.combinations.utils.combination_evaluator import AggregatedSample
+from AutoCarver.features import OrdinalFeature
+
+
+@pytest.fixture(params=[TschuprowtCombinations, CramervCombinations])
+def evaluator_cls(request):
+    return request.param
+
+
+def _make_evaluator(cls, xagg: pd.DataFrame, max_n_mod: int, min_freq: float, dp_top_k_initial: int):
+    """Fresh evaluator + fresh feature each call so state mutations don't leak."""
+    ev = cls()
+    ev.feature = OrdinalFeature("feature", list(xagg.index))
+    ev.samples.train = AggregatedSample(xagg.copy())
+    ev.samples.dev = AggregatedSample(xagg.copy())
+    ev.min_freq = min_freq
+    ev.max_n_mod = max_n_mod
+    ev.dp_top_k_initial = dp_top_k_initial
+    return ev
+
+
+@pytest.fixture
+def fixture_with_top_partition_unviable() -> pd.DataFrame:
+    """Construct a fixture where the top-metric partition fails ``min_freq``.
+
+    Counts are arranged so the partition that isolates the rare modality ``d``
+    (1 obs total) maximises chi² but fails ``min_freq=0.2`` (need ≥ 2 obs in
+    every group; ``d`` alone has 1 of 10 = 0.1). The walk must descend the
+    ranking to find a viable partition that merges ``d`` into a neighbour.
+    """
+    return pd.DataFrame(
+        {0: [3, 0, 0, 0], 1: [0, 3, 3, 1]},
+        index=["a", "b", "c", "d"],
+    )
+
+
+@pytest.mark.parametrize("dp_top_k_initial", [1, 2, 3, 5, 100, 10000])
+def test_progressive_top_k_finds_same_answer_regardless_of_initial(
+    fixture_with_top_partition_unviable,
+    evaluator_cls,
+    dp_top_k_initial: int,
+):
+    """Whatever ``dp_top_k_initial`` is set to, the doubling loop must return
+    the same viable winner.
+
+    This is the core correctness guarantee: a viable winner past rank N must
+    still be found regardless of the doubling start point.
+    """
+    ev = _make_evaluator(
+        evaluator_cls,
+        fixture_with_top_partition_unviable,
+        max_n_mod=3,
+        min_freq=0.2,
+        dp_top_k_initial=dp_top_k_initial,
+    )
+    result = ev._get_best_combination_non_nan()
+    assert result is not None, f"no viable found with dp_top_k_initial={dp_top_k_initial}"
+
+
+def test_progressive_top_k_all_initials_agree(fixture_with_top_partition_unviable, evaluator_cls):
+    """Stronger version: combination shape and metric values are identical
+    across all initial top_k settings."""
+    initials = [1, 2, 3, 5, 100, 10000]
+    results = []
+    for initial in initials:
+        ev = _make_evaluator(
+            evaluator_cls,
+            fixture_with_top_partition_unviable,
+            max_n_mod=3,
+            min_freq=0.2,
+            dp_top_k_initial=initial,
+        )
+        r = ev._get_best_combination_non_nan()
+        assert r is not None
+        results.append((initial, r["combination"], r["cramerv"], r["tschuprowt"]))
+
+    base = results[0]
+    for initial, combo, cv, tt in results[1:]:
+        assert combo == base[1], f"combination mismatch at dp_top_k_initial={initial}: {combo} vs {base[1]}"
+        assert math.isclose(cv, base[2], rel_tol=1e-12, abs_tol=1e-14), (
+            f"cramerv mismatch at dp_top_k_initial={initial}: {cv} vs {base[2]}"
+        )
+        assert math.isclose(tt, base[3], rel_tol=1e-12, abs_tol=1e-14), (
+            f"tschuprowt mismatch at dp_top_k_initial={initial}: {tt} vs {base[3]}"
+        )
+
+
+def test_progressive_top_k_returns_none_when_no_viable_exists(evaluator_cls):
+    """When every partition fails viability, the doubling loop must terminate
+    (when DP exhausts every partition: ``len(result) < top_k``) and return
+    ``None`` — not loop forever.
+    """
+    # min_freq high enough that no partition can pass: any group needs ≥ 0.7
+    # of the total observations; with N=6 that's 4.2, but each modality has 2
+    # so no 2-or-3-group split can put 4+ obs in *every* group.
+    xagg = pd.DataFrame({0: [1, 1, 1], 1: [1, 1, 1]}, index=["a", "b", "c"])
+    ev = _make_evaluator(evaluator_cls, xagg, max_n_mod=3, min_freq=0.7, dp_top_k_initial=1)
+    result = ev._get_best_combination_non_nan()
+    assert result is None
+
+
+def test_progressive_top_k_default_initial_is_fine_when_viable_at_top(evaluator_cls):
+    """When the top-metric partition is already viable, the loop completes in
+    the first iteration — no extra DP runs beyond the initial top_k."""
+    # Matches the existing pinned test test_get_best_combination_non_nan_viable
+    xagg = pd.DataFrame({0: [0, 2, 0], 1: [2, 0, 1]}, index=["a", "b", "c"])
+    ev = _make_evaluator(evaluator_cls, xagg, max_n_mod=2, min_freq=0.2, dp_top_k_initial=1000)
+    result = ev._get_best_combination_non_nan()
+    assert result is not None
+    assert result["combination"] == [["a"], ["b", "c"]]
+    assert result["cramerv"] == 0.25
+    assert result["tschuprowt"] == 0.25

--- a/tests/combinations/continuous/test_dp_kruskal_parity.py
+++ b/tests/combinations/continuous/test_dp_kruskal_parity.py
@@ -1,0 +1,190 @@
+"""Parity tests for the DP-based top-K Kruskal-Wallis segmentation path.
+
+SPEEDUP_PLAN §8.1. ``_top_k_partitions_kruskal_dp`` enumerates the K best
+*consecutive segmentations* of raw_index via an interval-DP over prefix sums,
+instead of the current enumerate-then-score loop. These tests assert that the
+DP's H values and partition shapes match the exhaustive enumeration path
+(``consecutive_combinations`` + ``_kruskal_h_for_combination``).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from AutoCarver.combinations.continuous.continuous_combination_evaluators import (
+    _kruskal_h_for_combination,
+    _modality_rank_stats,
+    _top_k_partitions_kruskal_dp,
+)
+from AutoCarver.combinations.utils.combinations import (
+    combination_formatter,
+    consecutive_combinations,
+)
+
+
+def _exhaustive_top_k(
+    raw_xagg: pd.Series,
+    max_n_mod: int,
+    top_k: int,
+) -> list[tuple[float, tuple[tuple, ...]]]:
+    """Brute-force: score every combination, keep the top-K by H desc.
+
+    Returns ``(H, combination_as_tuple_of_tuples)`` so combinations are
+    hashable for set comparisons.
+    """
+    raw_labels = list(raw_xagg.index)
+    R, n, N, tie_corr = _modality_rank_stats(raw_xagg)
+    mod_to_pos = {m: i for i, m in enumerate(raw_labels)}
+    n_mod = len(raw_labels)
+
+    scored: list[tuple[float, tuple[tuple, ...]]] = []
+    for combination in consecutive_combinations(raw_labels, max_n_mod):
+        h = _kruskal_h_for_combination(
+            R_per_mod=R,
+            n_per_mod=n,
+            N=N,
+            tie_corr=tie_corr,
+            mod_to_pos=mod_to_pos,
+            n_mod=n_mod,
+            index_to_groupby=combination_formatter(combination),
+        )
+        if h is None or math.isnan(h):
+            continue
+        scored.append((float(h), tuple(tuple(g) for g in combination)))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored[:top_k]
+
+
+def _dp_call(raw_xagg: pd.Series, max_n_mod: int, top_k: int) -> list[dict]:
+    R, n, N, tie_corr = _modality_rank_stats(raw_xagg)
+    return _top_k_partitions_kruskal_dp(
+        R,
+        n,
+        N,
+        tie_corr,
+        max_n_mod=max_n_mod,
+        raw_index=list(raw_xagg.index),
+        top_k=top_k,
+    )
+
+
+@pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("n_mod", [3, 5, 7, 10])
+def test_dp_top1_matches_exhaustive_no_ties(seed: int, n_mod: int):
+    """DP's single best H matches exhaustive best H on random continuous y."""
+    rng = np.random.default_rng(seed * 100 + n_mod)
+    sizes = rng.integers(2, 15, size=n_mod)
+    raw = {f"m{i}": rng.standard_normal(size=int(sizes[i])).tolist() for i in range(n_mod)}
+    xagg = pd.Series(raw)
+    max_n_mod = min(7, n_mod)
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=max_n_mod, top_k=10)
+    dp = _dp_call(xagg, max_n_mod=max_n_mod, top_k=10)
+
+    assert dp, "DP returned no candidates"
+    assert exhaustive, "exhaustive returned no candidates"
+    # closed form on prefix sums vs bincount — same math, different float order
+    assert math.isclose(dp[0]["kruskal"], exhaustive[0][0], rel_tol=1e-10, abs_tol=1e-12)
+
+
+@pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("n_mod", [3, 5, 7, 10])
+def test_dp_top_k_set_matches_exhaustive(seed: int, n_mod: int):
+    """Top-K *partitions* (modulo H ties) match exhaustive enumeration."""
+    rng = np.random.default_rng(seed * 100 + n_mod + 999)
+    sizes = rng.integers(2, 12, size=n_mod)
+    raw = {f"m{i}": rng.standard_normal(size=int(sizes[i])).tolist() for i in range(n_mod)}
+    xagg = pd.Series(raw)
+    max_n_mod = min(7, n_mod)
+    top_k = 25
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=max_n_mod, top_k=top_k)
+    dp = _dp_call(xagg, max_n_mod=max_n_mod, top_k=top_k)
+
+    # Compare H sequences pairwise to rtol=1e-10. Float order differs (prefix
+    # subtraction vs bincount accumulation) so bit-exactness isn't expected.
+    n_compare = min(len(exhaustive), len(dp))
+    assert n_compare > 0
+    for rank in range(n_compare):
+        h_dp = dp[rank]["kruskal"]
+        h_ex = exhaustive[rank][0]
+        assert math.isclose(h_dp, h_ex, rel_tol=1e-10, abs_tol=1e-12), (
+            f"rank {rank}: DP H={h_dp} vs exhaustive H={h_ex}"
+        )
+
+    # NOTE: partition-shape equality at rank 0 is *not* asserted. When two
+    # adjacent raw modalities have identical mean ranks (R_a/n_a == R_b/n_b),
+    # merging them leaves H unchanged — so multiple partitions are tied at
+    # the same H. The H equality above is the correctness invariant; tie
+    # resolution is implementation-defined and doesn't affect downstream
+    # viability semantics.
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_dp_handles_heavy_ties(seed: int):
+    """y drawn from a tiny integer alphabet → tie_corr < 1 but non-zero."""
+    rng = np.random.default_rng(seed + 4242)
+    n_mod = int(rng.integers(3, 7))
+    sizes = rng.integers(3, 10, size=n_mod)
+    raw = {f"m{i}": rng.integers(0, 4, size=int(sizes[i])).astype(float).tolist() for i in range(n_mod)}
+    xagg = pd.Series(raw)
+    max_n_mod = min(5, n_mod)
+
+    exhaustive = _exhaustive_top_k(xagg, max_n_mod=max_n_mod, top_k=5)
+    dp = _dp_call(xagg, max_n_mod=max_n_mod, top_k=5)
+
+    assert dp, "DP returned no candidates"
+    assert exhaustive, "exhaustive returned no candidates"
+    assert math.isclose(dp[0]["kruskal"], exhaustive[0][0], rel_tol=1e-10, abs_tol=1e-12)
+
+
+def test_dp_returns_empty_when_all_y_identical():
+    """tie_corr == 0 → DP returns [] (caller treats as no scorable combos)."""
+    xagg = pd.Series({"a": [1.0, 1.0, 1.0], "b": [1.0, 1.0], "c": [1.0, 1.0]})
+    result = _dp_call(xagg, max_n_mod=3, top_k=10)
+    assert result == []
+
+
+def test_dp_returns_empty_when_n_below_two():
+    xagg = pd.Series({"a": [1.0]})
+    result = _dp_call(xagg, max_n_mod=2, top_k=10)
+    assert result == []
+
+
+def test_dp_excludes_empty_modality_segments():
+    """A raw modality with zero observations must not appear as a singleton
+    group in the DP output (would give n_g == 0 → NaN H, matching the
+    exhaustive path which discards NaN scores)."""
+    xagg = pd.Series({"a": [1.0, 2.0, 3.0], "b": [], "c": [4.0, 5.0]})
+    result = _dp_call(xagg, max_n_mod=3, top_k=10)
+    # exhaustive path drops NaN scores → only partitions where "b" is merged
+    # with a neighbour are scorable. DP must agree.
+    for entry in result:
+        for group in entry["combination"]:
+            # "b" must not appear alone
+            assert group != ["b"]
+
+
+def test_dp_index_to_groupby_matches_combination_formatter():
+    """``index_to_groupby`` in DP output must equal
+    ``combination_formatter(combination)`` so downstream viability tests work
+    unchanged."""
+    rng = np.random.default_rng(0)
+    raw = {f"m{i}": rng.standard_normal(size=int(rng.integers(2, 8))).tolist() for i in range(6)}
+    xagg = pd.Series(raw)
+    result = _dp_call(xagg, max_n_mod=4, top_k=20)
+    for entry in result:
+        assert entry["index_to_groupby"] == combination_formatter(entry["combination"])
+
+
+def test_dp_output_is_sorted_desc_by_kruskal():
+    rng = np.random.default_rng(7)
+    raw = {f"m{i}": rng.standard_normal(size=int(rng.integers(3, 10))).tolist() for i in range(7)}
+    xagg = pd.Series(raw)
+    result = _dp_call(xagg, max_n_mod=5, top_k=30)
+    kruskals = [e["kruskal"] for e in result]
+    assert kruskals == sorted(kruskals, reverse=True)

--- a/tests/combinations/continuous/test_dp_progressive_top_k.py
+++ b/tests/combinations/continuous/test_dp_progressive_top_k.py
@@ -1,0 +1,154 @@
+"""Tests for the progressive top-K doubling loop in
+:meth:`ContinuousCombinationEvaluator._get_best_combination_non_nan`.
+
+SPEEDUP_PLAN §8.2. When the viable winner sits past ``dp_top_k_initial``,
+the DP must grow ``top_k`` (doubling each round) and keep walking until a
+viable candidate is found or every consecutive partition is exhausted.
+These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from AutoCarver.combinations.continuous.continuous_combination_evaluators import (
+    KruskalCombinations,
+)
+from AutoCarver.combinations.utils.combination_evaluator import AggregatedSample
+from AutoCarver.features import OrdinalFeature
+
+
+def _make_evaluator(xagg: pd.Series, max_n_mod: int, min_freq: float, dp_top_k_initial: int):
+    """Fresh evaluator + fresh feature each call so state mutations don't leak."""
+    ev = KruskalCombinations()
+    ev.feature = OrdinalFeature("feature", list(xagg.index))
+    ev.samples.train = AggregatedSample(xagg.copy())
+    ev.samples.dev = AggregatedSample(xagg.copy())
+    ev.min_freq = min_freq
+    ev.max_n_mod = max_n_mod
+    ev.dp_top_k_initial = dp_top_k_initial
+    return ev
+
+
+@pytest.fixture
+def fixture_with_top_h_unviable() -> pd.Series:
+    """Construct a fixture where the top-H partition fails ``min_freq``.
+
+    Per Kruskal-Wallis ranks: 3 zeros (rank ≈2 each), 6 fives (rank ≈6.5),
+    1 ten (rank 10). Putting ``d`` (the singleton 10) alone maximizes H but
+    fails ``min_freq = 0.2`` (need ≥ 2 obs per group; d has 1). The walk
+    must descend the H-ranking to find a viable partition that merges ``d``
+    into a neighbour.
+    """
+    return pd.Series(
+        {
+            "a": [0.0, 0.0, 0.0],
+            "b": [5.0, 5.0, 5.0],
+            "c": [5.0, 5.0, 5.0],
+            "d": [10.0],
+        }
+    )
+
+
+def test_top_h_partition_is_unviable_so_walk_must_descend(fixture_with_top_h_unviable):
+    """Sanity: with the chosen fixture, the rank-1 H partition really does fail
+    ``min_freq``. If this assumption breaks the doubling tests below become
+    trivially passing — so pin it explicitly.
+    """
+    from AutoCarver.combinations.continuous.continuous_combination_evaluators import (
+        _modality_rank_stats,
+        _top_k_partitions_kruskal_dp,
+    )
+
+    R, n, N, tc = _modality_rank_stats(fixture_with_top_h_unviable)
+    dp = _top_k_partitions_kruskal_dp(
+        R,
+        n,
+        N,
+        tc,
+        max_n_mod=3,
+        raw_index=list(fixture_with_top_h_unviable.index),
+        top_k=10,
+    )
+    # rank-1 must isolate "d" alone (1 obs → fails min_freq=0.2 needing ≥ 2 of 10)
+    rank1_groups = dp[0]["combination"]
+    assert any(g == ["d"] for g in rank1_groups), (
+        f"Test fixture invariant broken: rank-1 partition is {rank1_groups}, expected to isolate 'd' alone"
+    )
+
+
+@pytest.mark.parametrize("dp_top_k_initial", [1, 2, 3, 5, 100, 10000])
+def test_progressive_top_k_finds_same_answer_regardless_of_initial(
+    fixture_with_top_h_unviable,
+    dp_top_k_initial: int,
+):
+    """Whatever ``dp_top_k_initial`` is set to, the doubling loop must return
+    the same viable winner (which sits past rank 1 in this fixture).
+
+    This is the core correctness guarantee fixing the German-credit-style bug:
+    a viable winner past rank 1000 must still be found.
+    """
+    ev = _make_evaluator(fixture_with_top_h_unviable, max_n_mod=3, min_freq=0.2, dp_top_k_initial=dp_top_k_initial)
+    result = ev._get_best_combination_non_nan()
+    assert result is not None, f"no viable found with dp_top_k_initial={dp_top_k_initial}"
+    # The viable winner has higher kruskal than the legacy enumeration would
+    # have picked? No — DP and legacy pick the SAME first viable in H-desc
+    # order. We pin both the combination shape and the H below.
+    assert result["combination"] == [["a"], ["b"], ["c", "d"]], (
+        f"dp_top_k_initial={dp_top_k_initial}: got combination {result['combination']}"
+    )
+
+
+def test_progressive_top_k_all_initials_agree(fixture_with_top_h_unviable):
+    """Stronger version of the above: H value (not just combination shape) is
+    identical across all initial top_k settings."""
+    initials = [1, 2, 3, 5, 100, 10000]
+    results = []
+    for initial in initials:
+        ev = _make_evaluator(fixture_with_top_h_unviable, max_n_mod=3, min_freq=0.2, dp_top_k_initial=initial)
+        r = ev._get_best_combination_non_nan()
+        results.append((initial, r["combination"], r["kruskal"]))
+
+    base_combo, base_h = results[0][1], results[0][2]
+    for initial, combo, h in results[1:]:
+        assert combo == base_combo, f"combination mismatch at dp_top_k_initial={initial}: {combo} vs {base_combo}"
+        assert math.isclose(h, base_h, rel_tol=1e-12, abs_tol=1e-14), (
+            f"H mismatch at dp_top_k_initial={initial}: {h} vs {base_h}"
+        )
+
+
+def test_progressive_top_k_returns_none_when_no_viable_exists():
+    """When every partition fails viability, the doubling loop must terminate
+    (when DP exhausts every partition: ``len(result) < top_k``) and return
+    ``None`` — not loop forever.
+    """
+    # min_freq high enough that no partition can pass: any group needs ≥ 4 obs
+    # but total N = 6, so 2-group partitions can't both meet min_freq.
+    xagg = pd.Series(
+        {
+            "a": [0.0, 0.0],
+            "b": [5.0, 5.0],
+            "c": [10.0, 10.0],
+        }
+    )
+    ev = _make_evaluator(xagg, max_n_mod=3, min_freq=0.7, dp_top_k_initial=1)
+    result = ev._get_best_combination_non_nan()
+    assert result is None
+
+
+def test_progressive_top_k_default_initial_is_fine_when_viable_at_top():
+    """When the top-H partition is already viable, the loop completes in the
+    first iteration — no extra DP runs beyond the initial top_k."""
+    # Simple fixture: all modalities have ≥ 2 obs, modest separation; top-H
+    # passes min_freq=0.2 (N=7, need ≥ 1.4 → all groups have ≥ 2 obs).
+    xagg = pd.Series({"a": [0, 2, 0], "b": [2, 1], "c": [2, 0]})
+    ev = _make_evaluator(xagg, max_n_mod=2, min_freq=0.2, dp_top_k_initial=1000)
+    result = ev._get_best_combination_non_nan()
+    assert result is not None
+    # Matches the existing pinned-value test
+    # `test_get_best_combination_non_nan_viable`
+    assert result["combination"] == [["a"], ["b", "c"]]
+    assert result["kruskal"] == 0.5833333333333333

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "autocarver"
-version = "7.2.2"
+version = "7.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
- Ships interval-DP over consecutive segmentations for `KruskalCombinations` and `ChiSquaredCombinations`, with progressive top-K doubling so the search stays exhaustive in the worst case.
